### PR TITLE
syncs documentation for v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.9.0
+## Changes
+- Adds support for CRAM input and output files
+- The reference file (`--reference`) is now a required parameter for HiPhase. This prevents users from accidentally forgetting the reference file which leads to drastically different performance.
+
+## Fixed
+- Corrected an error where bgzipped reference files were not correctly loading
+
 # v0.8.1
 ## Changes
 - Adds `--ignore-read-groups` flag that will skip the read group checks for provided BAM files. This option can only be used to phase one dataset at a time. Resolves #3.

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,8 @@
+@article{holt2023hiphase,
+  title={HiPhase: Jointly phasing small and structural variants from HiFi sequencing},
+  author={Holt, James M and Saunders, Christopher T and Rowell, William J and Kronenberg, Zev and Wenger, Aaron M and Eberle, Michael},
+  journal={bioRxiv},
+  pages={2023--05},
+  year={2023},
+  publisher={Cold Spring Harbor Laboratory}
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ We are still tweaking the input / output file formats and making changes that ca
 * [Methods](docs/methods.md)
 * [Performance](docs/performance.md)
 
+## Citation
+If you use HiPhase, please cite our pre-print:
+
+[Holt, J. M., Saunders, C. T., Rowell, W. J., Kronenberg, Z., Wenger, A. M., & Eberle, M. (2023). HiPhase: Jointly phasing small and structural variants from HiFi sequencing. _bioRxiv_, 2023-05.](https://doi.org/10.1101/2023.05.03.539241)
+
 ## Need help?
 If you notice any missing features, bugs, or need assistance with analyzing the output of HiPhase, 
 please don't hesitate to [reach out by email](mailto:mholt@pacificbiosciences.com) or open a GitHub issue.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -21,7 +21,7 @@ Parameters:
 * `--bam {IN_BAM}` - path to a BAM file containing reads only from the sample that is being phased, this option can be specified multiple times; each BAM file can only contain reads from a single sample
 * `--vcf {IN_VCF}` - path to a VCF file containing the variants to phase, this option can be specified multiple times; each sample being phased must appear in each provided VCF file
 * `--output-vcf {OUT_VCF}` - path to the output VCF that will contain the phased variants, this option must be specified the same number of times as `--vcf` 
-* `--reference {REFERENCE}` - a FASTA file containing the reference genome, gzip allowed; the reference genome file is optional, but _very strongly_ recommended for optimal performance
+* `--reference {REFERENCE}` - a FASTA file containing the reference genome, gzip allowed; as of v0.9.0, this is a required parameter
 * `--threads {THREADS}` - number of threads to use for phasing (default: 1)
 
 ## Quickstart Example
@@ -85,7 +85,6 @@ hiphase \
 To *jointly* phase small variants and SVs, pass both VCF files to HiPhase and specify two output VCF files in the same order as input.
 Currently, DeepVariant and pbsv are the two supported input types.
 While not required, it is *recommended* that global re-alignment is enabled when SVs are used.
-If global re-alignment is used, a reference genome file _must_ be provided via `--reference {REFERENCE}`.
 
 ```bash
 hiphase \


### PR DESCRIPTION
# v0.9.0
## Changes
- Adds support for CRAM input and output files. Resolves #6.
- The reference file (`--reference`) is now a required parameter for HiPhase. This prevents users from accidentally forgetting the reference file which leads to drastically different performance.

## Fixed
- Corrected an error where bgzipped reference files were not correctly loading
