### PR TITLE
note the panic fix in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.10.2
+## Fixed
+- Replaced a panic caused by large WFA edit distance with a human-readable error message (Resolves #15)
+
 # v0.10.1
 ## Fixed
 - Corrected a panic caused by reference mismatches to produce a human-readable error message (Resolves #12)


### PR DESCRIPTION
# v0.10.2
## Fixed
- Replaced a panic caused by large WFA edit distance with a human-readable error message (Resolves #15)