### PR TITLE
changes for v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.1.0
+## Changes
+- Updated the way unphaseable variants are placed into artificial phase blocks. Instead of unphased singletons, these are now grouped into larger unphased blocks. Phased variants are unaffected by this change.
+  - This has a major impact on I/O churning, especially in centromeric and telomeric regions. Internal tests show up to 60% reduction in wall clock time with 16 threads accompanied by up to 30% reduction in CPU time depending on the phasing mode.
+  - There are now fewer total phase blocks reported due to the singleton collapse. This primarily impacts the statistic tracking optional outputs of HiPhase.
+
+## Fixed
+- Fixed a related issue where unphased singleton blocks were falsely tagged with `TR_OVERLAP`
+- Fixed an issue where the default `--io-threads` frequently caused issues on long-running jobs. This now defaults to `min(--threads, 4)`, but can still be specified with `--io-threads`.
+
 # v1.0.0
 ## Changes
 - Added support for tandem repeat calls from [TRGT](https://github.com/PacificBiosciences/trgt); minimum supported version - v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "hiphase"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bio",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "hiphase"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["J. Matthew Holt <mholt@pacificbiosciences.com>"]
-description = "A tool for phasing HiFi VCF files."
+description = "A tool for jointly phasing small, structural, and tandem repeat variants for PacBio sequencing data"
 edition = "2021"
 license-file="LICENSE.md"
 

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -496,12 +496,12 @@
   },
   {
     "name": "hiphase",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "authors": "J. Matthew Holt <mholt@pacificbiosciences.com>",
     "repository": null,
     "license": null,
     "license_file": "LICENSE.md",
-    "description": "A tool for phasing HiFi VCF files."
+    "description": "A tool for jointly phasing small, structural, and tandem repeat variants for PacBio sequencing data"
   },
   {
     "name": "hts-sys",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,7 +99,7 @@ pub struct Settings {
     #[clap(help_heading = Some("Input/Output"))]
     pub haplotag_filename: Option<PathBuf>,
 
-    /// Number of threads for BAM I/O (default: copy `--threads`)
+    /// Number of threads for BAM I/O (default: minimum of `--threads` or `4`)
     #[clap(long = "io-threads")]
     #[clap(value_name = "THREADS")]
     #[clap(help_heading = Some("Input/Output"))]
@@ -311,7 +311,9 @@ pub fn check_settings(mut settings: Settings) -> Settings {
 
     // if this is not specified, then set it to the same as processing
     if settings.io_threads.is_none() {
-        settings.io_threads = Some(settings.threads);
+        // setting to the same as threads generates some issues with no real benefit
+        // 4 is a happy default, users can override if needed
+        settings.io_threads = Some(settings.threads.min(4));
     }
 
     // dump stuff to the logger

--- a/src/data_types/variants.rs
+++ b/src/data_types/variants.rs
@@ -42,7 +42,7 @@ pub enum Zygosity {
 
 /// A variant definition structure.
 /// It currently assumes that chromosome is fixed and that the variant is a SNP.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Variant {
     /// The vcf index from the input datasets
     vcf_index: usize,


### PR DESCRIPTION
# v1.1.0
## Changes
- Updated the way unphaseable variants are placed into artificial phase blocks. Instead of unphased singletons, these are now grouped into larger unphased blocks. Phased variants are unaffected by this change.
  - This has a major impact on I/O churning, especially in centromeric and telomeric regions. Internal tests show up to 60% reduction in wall clock time with 16 threads accompanied by up to 30% reduction in CPU time depending on the phasing mode.
  - There are now fewer total phase blocks reported due to the singleton collapse. This primarily impacts the statistic tracking optional outputs of HiPhase.