### PR TITLE
synching of csi_indexing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.2.0
+## Changes
+- Added an option (`--csi-index`) to output .csi index files instead of .tbi/.bai
+- HiPhase will now generate an error if it detects a large reference chromosome and .csi indexing is not enabled
+
 # v1.1.0
 ## Changes
 - Updated the way unphaseable variants are placed into artificial phase blocks. Instead of unphased singletons, these are now grouped into larger unphased blocks. Phased variants are unaffected by this change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "hiphase"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bio",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiphase"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["J. Matthew Holt <mholt@pacificbiosciences.com>"]
 description = "A tool for jointly phasing small, structural, and tandem repeat variants for PacBio sequencing data"
 edition = "2021"

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -496,7 +496,7 @@
   },
   {
     "name": "hiphase",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "authors": "J. Matthew Holt <mholt@pacificbiosciences.com>",
     "repository": null,
     "license": null,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,6 +105,11 @@ pub struct Settings {
     #[clap(help_heading = Some("Input/Output"))]
     pub io_threads: Option<usize>,
 
+    /// Output .csi indices instead of .tbi/.bai
+    #[clap(long = "csi-index")]
+    #[clap(help_heading = Some("Input/Output"))]
+    pub csi_index: bool,
+
     /// Number of threads to use for phasing.
     #[clap(short = 't')]
     #[clap(long = "threads")]
@@ -339,6 +344,9 @@ pub fn check_settings(mut settings: Settings) -> Settings {
     }
     info!("Processing threads: {}", settings.threads);
     info!("I/O threads: {}", settings.io_threads.unwrap());
+    if settings.csi_index {
+        info!("CSI indexing: enabled");
+    }
 
     //send the settings back
     settings


### PR DESCRIPTION
v1.2.0
## Changes
- Added an option (`--csi-index`) to output .csi index files instead of .tbi/.bai
- HiPhase will now generate an error if it detects a large reference chromosome and .csi indexing is not enabled