### PR TITLE
syncing changes for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.3.0
+## Changes
+- Relaxes the requirements for SV deletion and insertion events such that they no longer require an alternate or reference allele, respectively, to have length 1
+
+## Internal changes
+- The interface for variant creation was modified to reduce panics from invalid variant construction. This modification changes all the return types for the various `Variant::new*(...)` functions from `Variant` to `Result<Variant, VariantError>`.
+
+## Fixed
+- SV events with a placeholder ALT sequence (e.g., \<DEL\>, \<INS\>) are now properly ignored by HiPhase instead of creating an error.
+
 # v1.2.1
 ## Fixed
 - Fixed [a rare issue](https://github.com/PacificBiosciences/pbbioconda/issues/640) where reference alleles with stripped IUPAC codes were throwing errors due to reference mismatch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -357,7 +357,7 @@ checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ checksum = "84278eae0af6e34ff6c1db44c11634a694aafac559ff3080e4db4e4ac35907aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -491,7 +491,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "hiphase"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "bio",
  "bit-vec",
@@ -541,6 +541,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "simple-error",
+ "thiserror",
  "threadpool",
  "vergen",
 ]
@@ -775,7 +776,7 @@ checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -933,7 +934,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "version_check",
 ]
 
@@ -950,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -965,9 +966,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1127,7 +1128,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -1184,7 +1185,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -1192,6 +1193,17 @@ name = "syn"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1209,22 +1221,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1407,7 +1419,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -1429,7 +1441,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiphase"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["J. Matthew Holt <mholt@pacificbiosciences.com>"]
 description = "A tool for jointly phasing small, structural, and tandem repeat variants for PacBio sequencing data"
 edition = "2021"
@@ -31,6 +31,7 @@ rust-htslib = { version = "0.39.5", default-features = false, features = ["stati
 rustc-hash = "1.1.0"
 serde = "1.0.147"
 simple-error = "0.2.3"
+thiserror = "1.0.56"
 threadpool = "1.8.1"
 
 [profile.release]

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -496,7 +496,7 @@
   },
   {
     "name": "hiphase",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "authors": "J. Matthew Holt <mholt@pacificbiosciences.com>",
     "repository": null,
     "license": null,
@@ -910,7 +910,7 @@
   },
   {
     "name": "proc-macro2",
-    "version": "1.0.58",
+    "version": "1.0.78",
     "authors": "David Tolnay <dtolnay@gmail.com>|Alex Crichton <alex@alexcrichton.com>",
     "repository": "https://github.com/dtolnay/proc-macro2",
     "license": "Apache-2.0 OR MIT",
@@ -928,7 +928,7 @@
   },
   {
     "name": "quote",
-    "version": "1.0.27",
+    "version": "1.0.35",
     "authors": "David Tolnay <dtolnay@gmail.com>",
     "repository": "https://github.com/dtolnay/quote",
     "license": "Apache-2.0 OR MIT",
@@ -1161,6 +1161,15 @@
     "description": "Parser for Rust source code"
   },
   {
+    "name": "syn",
+    "version": "2.0.48",
+    "authors": "David Tolnay <dtolnay@gmail.com>",
+    "repository": "https://github.com/dtolnay/syn",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "Parser for Rust source code"
+  },
+  {
     "name": "termcolor",
     "version": "1.1.3",
     "authors": "Andrew Gallant <jamslam@gmail.com>",
@@ -1171,7 +1180,7 @@
   },
   {
     "name": "thiserror",
-    "version": "1.0.37",
+    "version": "1.0.56",
     "authors": "David Tolnay <dtolnay@gmail.com>",
     "repository": "https://github.com/dtolnay/thiserror",
     "license": "Apache-2.0 OR MIT",
@@ -1180,7 +1189,7 @@
   },
   {
     "name": "thiserror-impl",
-    "version": "1.0.37",
+    "version": "1.0.56",
     "authors": "David Tolnay <dtolnay@gmail.com>",
     "repository": "https://github.com/dtolnay/thiserror",
     "license": "Apache-2.0 OR MIT",

--- a/src/block_gen.rs
+++ b/src/block_gen.rs
@@ -152,7 +152,7 @@ pub fn is_phasable_variant(record: &bcf::Record, sample_index: usize, min_qualit
             VariantType::SvDuplication |
             VariantType::SvInversion |
             VariantType::SvBreakend |
-            VariantType::Unknown=> { Ok(false) }
+            VariantType::Unknown => { Ok(false) }
         }
     }
 }
@@ -231,6 +231,12 @@ pub fn get_variant_type(record: &bcf::Record) -> Result<VariantType, Box<dyn std
                 // make sure these only have one ALT allele
                 let num_alleles = record.alleles().len();
                 assert_eq!(num_alleles, 2);
+
+                // make sure the alternate allele is not a placeholder like <DEL>; if so, return Unknown because we do not want to phase it
+                let alt_allele = std::str::from_utf8(record.alleles()[1]).unwrap_or("<unknown>");
+                if alt_allele.starts_with('<') && alt_allele.ends_with('>') {
+                    return Ok(VariantType::Unknown);
+                }
                 
                 let svtype_str = std::str::from_utf8(svtype[0]).unwrap();
                 let sv_tag = match svtype_str {

--- a/src/wfa_graph.rs
+++ b/src/wfa_graph.rs
@@ -821,7 +821,7 @@ mod tests {
     #[test]
     fn test_simple_snv() {
         let reference = "AAA".as_bytes();
-        let variants = vec![Variant::new_snv(0, 1, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1)];
+        let variants = vec![Variant::new_snv(0, 1, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap()];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
             WFAGraph::from_reference_variants(&reference, &variants, 0, reference.len()).unwrap();
@@ -846,8 +846,8 @@ mod tests {
         let reference = "AAAAA".as_bytes();
         let variants = vec![
             // vcf_index, position, allele0, allele1, index_allele0, index_allele1
-            Variant::new_snv(0, 1, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1),
-            Variant::new_snv(0, 3, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1)
+            Variant::new_snv(0, 1, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap(),
+            Variant::new_snv(0, 3, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap()
         ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
@@ -886,8 +886,8 @@ mod tests {
         let reference = "ACGTA".as_bytes();
         let variants = vec![
             // vcf_index, position, ref_len, allele0, allele1, index_allele0, index_allele1
-            Variant::new_deletion(0, 1, 2, "CG".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1),
-            Variant::new_deletion(0, 2, 2, "GT".as_bytes().to_vec(), "G".as_bytes().to_vec(), 0, 1)
+            Variant::new_deletion(0, 1, 2, "CG".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap(),
+            Variant::new_deletion(0, 2, 2, "GT".as_bytes().to_vec(), "G".as_bytes().to_vec(), 0, 1).unwrap()
         ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
@@ -925,8 +925,8 @@ mod tests {
         let reference = "ACGTA".as_bytes();
         let variants = vec![
             // vcf_index, position, allele0, allele1, index_allele0, index_allele1
-            Variant::new_insertion(0, 2, "G".as_bytes().to_vec(), "GT".as_bytes().to_vec(), 0, 1),
-            Variant::new_insertion(1, 2, "G".as_bytes().to_vec(), "GT".as_bytes().to_vec(), 0, 1)
+            Variant::new_insertion(0, 2, "G".as_bytes().to_vec(), "GT".as_bytes().to_vec(), 0, 1).unwrap(),
+            Variant::new_insertion(1, 2, "G".as_bytes().to_vec(), "GT".as_bytes().to_vec(), 0, 1).unwrap()
         ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
@@ -958,7 +958,7 @@ mod tests {
         let reference = "ACGTA".as_bytes();
         let variants = vec![
             // vcf_index, position, ref_len, allele0, allele1, index_allele0, index_allele1
-            Variant::new_indel(0, 2, 2, "G".as_bytes().to_vec(), "GTT".as_bytes().to_vec(), 1, 2)
+            Variant::new_indel(0, 2, 2, "G".as_bytes().to_vec(), "GTT".as_bytes().to_vec(), 1, 2).unwrap()
         ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
@@ -991,7 +991,9 @@ mod tests {
         // we prepended and appended "AA" to the basic SNV test
         let reference = "AAAAAAA".as_bytes();
         // variant coordinate shifted +2
-        let variants = vec![Variant::new_snv(0, 3, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1)];
+        let variants = vec![
+            Variant::new_snv(0, 3, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap()
+        ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
             WFAGraph::from_reference_variants(&reference, &variants, 2, reference.len()-2).unwrap();
@@ -1016,12 +1018,12 @@ mod tests {
         let variants = vec![
             // vcf_index, position, ref_len, allele0, allele1, index_allele0, index_allele1
             // 3: GTTG>G
-            Variant::new_deletion(0, 3, 4, "GTTG".as_bytes().to_vec(), "G".as_bytes().to_vec(), 0, 1),
+            Variant::new_deletion(0, 3, 4, "GTTG".as_bytes().to_vec(), "G".as_bytes().to_vec(), 0, 1).unwrap(),
             // 4: TT>T
-            Variant::new_deletion(0, 4, 2, "TT".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1),
+            Variant::new_deletion(0, 4, 2, "TT".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1).unwrap(),
             // vcf_index, position, allele0, allele1, index_allele0, index_allele1
             // 6: G>[A,C]
-            Variant::new_snv(0, 6, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 1, 2)
+            Variant::new_snv(0, 6, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 1, 2).unwrap()
         ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
@@ -1076,8 +1078,8 @@ mod tests {
         // the first one should be ignored, the second one included
         let variants = vec![
             // vcf_index, position, allele0, allele1, index_allele0, index_allele1
-            Variant::new_snv(0, (ref_start-1) as i64, "A".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1),
-            Variant::new_snv(0, ref_start as i64, "A".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1)
+            Variant::new_snv(0, (ref_start-1) as i64, "A".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1).unwrap(),
+            Variant::new_snv(0, ref_start as i64, "A".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1).unwrap()
         ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
@@ -1100,7 +1102,7 @@ mod tests {
         let reference = "ACGTA".as_bytes();
         let variants = vec![
             // vcf_index, position, ref_len, allele0, allele1, index_allele0, index_allele1
-            Variant::new_deletion(0, 3, 3, "TAG".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1)
+            Variant::new_deletion(0, 3, 3, "TAG".as_bytes().to_vec(), "T".as_bytes().to_vec(), 0, 1).unwrap()
         ];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
@@ -1117,8 +1119,8 @@ mod tests {
     fn test_hom_variants() {
         // add a hom variant at base 1; these can be traversed, but provide no index lookup because they are not a "variant"
         let reference = "AAAAA".as_bytes();
-        let variants = vec![Variant::new_snv(0, 3, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1)];
-        let hom_variants = vec![Variant::new_snv(0, 1, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1)];
+        let variants = vec![Variant::new_snv(0, 3, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap()];
+        let hom_variants = vec![Variant::new_snv(0, 1, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap()];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
             WFAGraph::from_reference_variants_with_hom(&reference, &variants, &hom_variants, 0, reference.len()).unwrap();
@@ -1144,7 +1146,7 @@ mod tests {
     #[test]
     fn test_variant_at_start() {
         let reference = "AAA".as_bytes();
-        let variants = vec![Variant::new_snv(0, 0, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1)];
+        let variants = vec![Variant::new_snv(0, 0, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap()];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
             WFAGraph::from_reference_variants(&reference, &variants, 0, reference.len()).unwrap();
@@ -1166,7 +1168,7 @@ mod tests {
     #[test]
     fn test_variant_at_end() {
         let reference = "AAA".as_bytes();
-        let variants = vec![Variant::new_snv(0, 2, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1)];
+        let variants = vec![Variant::new_snv(0, 2, "A".as_bytes().to_vec(), "C".as_bytes().to_vec(), 0, 1).unwrap()];
 
         let (graph, node_to_alleles): (WFAGraph, NodeAlleleMap) = 
             WFAGraph::from_reference_variants(&reference, &variants, 0, reference.len()).unwrap();


### PR DESCRIPTION
# v1.3.0
## Changes
- Relaxes the requirements for SV deletion and insertion events such that they no longer require an alternate or reference allele, respectively, to have length 1

## Internal changes
- The interface for variant creation was modified to reduce panics from invalid variant construction. This modification changes all the return types for the various `Variant::new*(...)` functions from `Variant` to `Result<Variant, VariantError>`.

## Fixed
- SV events with a placeholder ALT sequence (e.g., \<DEL\>, \<INS\>) are now properly ignored by HiPhase instead of creating an error.