### PR TITLE
minor patch for TRGT 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.2
+## Changes
+* Removes a 1 basepair shift from tandem repeat region calculation to support anchor base changes in TRGT v1.0.0; internal results are nearly identical before and after this change
+
 # v1.4.1
 ## Changes
 * Reclassifies warnings during VCF writing to debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "hiphase"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bio",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiphase"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["J. Matthew Holt <mholt@pacificbiosciences.com>"]
 description = "A tool for jointly phasing small, structural, and tandem repeat variants for PacBio sequencing data"
 edition = "2021"

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -496,7 +496,7 @@
   },
   {
     "name": "hiphase",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "authors": "J. Matthew Holt <mholt@pacificbiosciences.com>",
     "repository": null,
     "license": null,

--- a/src/phaser.rs
+++ b/src/phaser.rs
@@ -452,10 +452,9 @@ pub fn solve_block(
             let start: i64 = variant.position();
             let ref_len: usize = variant.get_ref_len();
             let end: i64 = start + ref_len as i64;
-            // sometimes TRGT inserts the base before which will match an insertion and sometimes it won't - confirmed with Egor
-            // we can't really tell which is which though, so lets just substract 1 from the start and assume that's the best for now
-            // TODO: if TRGT adjusts to always have an anchor, we will need to drop the "-1" operation
-            tr_segments.insert((start-1)..end, 0);
+            // prior to TRGT v1.0.0: sometimes TRGT inserts the base before which will match an insertion and sometimes it wouldn't
+            // now there is always an anchor base, so we can safely just use start..end from the VCF directly
+            tr_segments.insert(start..end, 0);
         }
     }
 


### PR DESCRIPTION
# v1.4.2
## Changes
* Removes a 1 basepair shift from tandem repeat region calculation to support anchor base changes in TRGT v1.0.0; internal results are nearly identical before and after this change