### PR TITLE
changes to patch bug in bam tag removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.5
+## Fixed
+* Fixed an error where BAM phase tags were not always properly removed prior to re-tagging, leading to a run-time error and exit
+
 # v1.4.4
 ## Fixed
 * Fixed an error where phasing information that was present in input files would be copied through to output files if it was not overwritten by HiPhase phasing results. HiPhase will now automatically remove this phasing information to prevent accidental mixing of phase results. 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "hiphase"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "bio",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiphase"
-version = "1.4.4"
+version = "1.4.5"
 authors = ["J. Matthew Holt <mholt@pacificbiosciences.com>"]
 description = "A tool for jointly phasing small, structural, and tandem repeat variants for PacBio sequencing data"
 edition = "2021"

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -496,7 +496,7 @@
   },
   {
     "name": "hiphase",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "authors": "J. Matthew Holt <mholt@pacificbiosciences.com>",
     "repository": null,
     "license": null,


### PR DESCRIPTION
# v1.4.5
## Fixed
* Fixed an error where BAM phase tags were not always properly removed prior to re-tagging, leading to a run-time error and exit