### PR TITLE
changes for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.5.0
+## Changes
+* Reduced memory footprint for large putative phase blocks by adjusting algorithms for storing read segment variants. Overall, this change has a negligible impact on memory usage for a typical human WGS dataset. However, sample types with much higher heterozygous variants per phase block (e.g., mouse) have significantly less peak memory usage (>80% reduction on tests).
+* Minor tweaks to phasing methods to reduce overhead of tracking candidate phase solutions
+* Internal results are highly similar, but not identical, to results for v1.4.5
+
 # v1.4.5
 ## Fixed
 * Fixed an error where BAM phase tags were not always properly removed prior to re-tagging, leading to a run-time error and exit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,8 +90,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "statrs",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "thiserror",
  "triple_accel",
  "vec_map",
@@ -106,7 +106,7 @@ dependencies = [
  "derive-new",
  "lazy_static",
  "regex",
- "strum_macros",
+ "strum_macros 0.24.3",
  "thiserror",
 ]
 
@@ -228,7 +228,7 @@ version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -516,6 +516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "hiphase"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "bio",
  "bit-vec",
@@ -544,6 +550,8 @@ dependencies = [
  "rustc-hash",
  "serde",
  "simple-error",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "thiserror",
  "threadpool",
  "vergen",
@@ -1191,16 +1199,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
  "syn 1.0.102",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiphase"
-version = "1.4.5"
+version = "1.5.0"
 authors = ["J. Matthew Holt <mholt@pacificbiosciences.com>"]
 description = "A tool for jointly phasing small, structural, and tandem repeat variants for PacBio sequencing data"
 edition = "2021"
@@ -31,6 +31,8 @@ rust-htslib = { version = "0.39.5", default-features = false, features = ["stati
 rustc-hash = "1.1.0"
 serde = "1.0.147"
 simple-error = "0.2.3"
+strum = "0.27.1"
+strum_macros = "0.27.1"
 thiserror = "1.0.56"
 threadpool = "1.8.1"
 

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -486,6 +486,15 @@
     "description": "heck is a case conversion library."
   },
   {
+    "name": "heck",
+    "version": "0.5.0",
+    "authors": null,
+    "repository": "https://github.com/withoutboats/heck",
+    "license": "Apache-2.0 OR MIT",
+    "license_file": null,
+    "description": "heck is a case conversion library."
+  },
+  {
     "name": "hermit-abi",
     "version": "0.1.19",
     "authors": "Stefan Lankes",
@@ -496,7 +505,7 @@
   },
   {
     "name": "hiphase",
-    "version": "1.4.5",
+    "version": "1.5.0",
     "authors": "J. Matthew Holt <mholt@pacificbiosciences.com>",
     "repository": null,
     "license": null,
@@ -1161,8 +1170,26 @@
     "description": "Helpful macros for working with enums and strings"
   },
   {
+    "name": "strum",
+    "version": "0.27.1",
+    "authors": "Peter Glotfelty <peter.glotfelty@microsoft.com>",
+    "repository": "https://github.com/Peternator7/strum",
+    "license": "MIT",
+    "license_file": null,
+    "description": "Helpful macros for working with enums and strings"
+  },
+  {
     "name": "strum_macros",
     "version": "0.24.3",
+    "authors": "Peter Glotfelty <peter.glotfelty@microsoft.com>",
+    "repository": "https://github.com/Peternator7/strum",
+    "license": "MIT",
+    "license_file": null,
+    "description": "Helpful macros for working with enums and strings"
+  },
+  {
+    "name": "strum_macros",
+    "version": "0.27.1",
     "authors": "Peter Glotfelty <peter.glotfelty@microsoft.com>",
     "repository": "https://github.com/Peternator7/strum",
     "license": "MIT",

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -84,8 +84,9 @@ hiphase \
 
 ## Recommended resources
 HiPhase has built in parallel processing via the `--threads` parameter.
-We recommend reserving 4 GB of memory per thread allocated to HiPhase.
+For a typical human whole genome with ~30x coverage, we recommend reserving 4 GB of memory per thread allocated to HiPhase.
 For example, most of our internal tests use 16 threads and reserve 64 GB of memory.
+Both memory and compute time scale with the number of heterozygous variants and reads in a dataset, so samples with significantly higher heterozygosity or sequencing depth than a typical 30x human genome may require more resources.
 
 # Common use cases
 ## Joint phasing small variants, structural variants, and tandem repeats

--- a/src/data_types/read_segments.rs
+++ b/src/data_types/read_segments.rs
@@ -1,4 +1,29 @@
 
+use std::ops::Range;
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, strum_macros::FromRepr)]
+pub enum AlleleType {
+    Reference=0,
+    Alternate=1,
+    Ambiguous=2,
+    NoOverlap=3
+}
+
+/*
+impl From<u8> for AlleleType {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => AlleleType::Reference,
+            1 => AlleleType::Alternate,
+            2 => AlleleType::Ambiguous,
+            3 => AlleleType::NoOverlap,
+            _ => AlleleType::NoOverlap
+        }
+    }
+}
+*/
+
 /// Container for a read segment that has been converted into a variant representation
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReadSegment {
@@ -6,13 +31,11 @@ pub struct ReadSegment {
     read_name: String,
     /// the actual alleles for the read, should always be 0, 1, 2 (ambiguous), or 3 (non-overlapping/undefined).
     /// anything other than 0 or 1 are basically ignored in all functions
-    alleles: Vec<u8>,
+    alleles: Vec<AlleleType>,
     /// the associated quality values for converting 0 <--> 1; undefined alleles should have qual == 0
     quals: Vec<u8>,
-    /// the index of the first defined 0/1 allele, inclusive
-    first_allele: usize,
-    /// the index of the last defined 0/1 allele, inclusive
-    last_allele: usize
+    /// the range that is stored in alleles and quals
+    region: Range<usize>
 }
 
 impl ReadSegment {
@@ -23,18 +46,27 @@ impl ReadSegment {
     /// * `quals` - cost to convert an allele from 0 <--> 1, any undefined/ambiguous alleles should be qual = 0
     /// # Panics
     /// * if `allele.len() != quals.len()`
-    pub fn new(read_name: String, alleles: Vec<u8>, quals: Vec<u8>) -> ReadSegment {
+    pub fn new(read_name: String, alleles: Vec<AlleleType>, quals: Vec<u8>) -> ReadSegment {
         assert_eq!(alleles.len(), quals.len());
+
+        // this used to be defined by < Ambiguous, but I think we want to keep ambiguous around now
         let (first_allele, _) = alleles.iter().enumerate()
-            .find(|(_i, &a)| a < 2).unwrap_or((alleles.len(), &2));
-        let (last_allele, _) = alleles.iter().enumerate().rev()
-            .find(|(_i, &a)| a < 2).unwrap_or((alleles.len(), &2));
+            .find(|(_i, &a)| a < AlleleType::Ambiguous).unwrap_or((alleles.len(), &AlleleType::NoOverlap));
+        let last_allele = alleles.iter().enumerate().rev()
+            .find(|(_i, &a)| a < AlleleType::Ambiguous) // find the last index that is set
+            .map(|(i, _a)| i+1) // increment it by one since we are using exclusive-ended Range
+            .unwrap_or(alleles.len()); // if we do not find one, set it to the length
+
+        // compile the region and cut it out of the provided data
+        let region = first_allele..last_allele;
+        let alleles = alleles[region.clone()].to_vec();
+        let quals = quals[region.clone()].to_vec();
+
         ReadSegment {
             read_name,
             alleles,
             quals,
-            first_allele,
-            last_allele
+            region
         }
     }
 
@@ -52,34 +84,40 @@ impl ReadSegment {
             return read_segments[0].clone();
         }
 
-        let num_alleles: usize = read_segments[0].get_num_alleles();
+        // figure out how large this region can be
+        let min_start = read_segments.iter().map(|rs| rs.region().start).min().unwrap();
+        let max_end = read_segments.iter().map(|rs| rs.region().end).max().unwrap();
+
+        // max_end is exclusive
         let read_name: String = read_segments[0].read_name().to_string();
-        let mut alleles: Vec<u8> = vec![3; num_alleles];
-        let mut quals: Vec<u8> = vec![0; num_alleles];
+        let mut alleles: Vec<AlleleType> = vec![AlleleType::NoOverlap; max_end];
+        let mut quals: Vec<u8> = vec![0; max_end];
+
         for rs in read_segments.iter() {
-            let rs_alleles = rs.alleles();
-            let rs_quals = rs.quals();
-            assert_eq!(num_alleles, rs.get_num_alleles());
             assert_eq!(read_name, rs.read_name());
 
-            for (i, &rsa) in rs_alleles.iter().enumerate() {
+            for i in min_start..max_end {
+                // now get the allele and quality
+                let rsa = rs.allele(i);
+                let rsq = rs.qual(i);
+
                 // if rsa is unset, we skip everything
-                if rsa != 3 {
-                    if alleles[i] == 3 {
+                if rsa != AlleleType::NoOverlap {
+                    if alleles[i] == AlleleType::NoOverlap {
                         alleles[i] = rsa;
-                        quals[i] = rs_quals[i];
-                    } else if alleles[i] == 2 {
+                        quals[i] = rsq;
+                    } else if alleles[i] == AlleleType::Ambiguous {
                         // we are already ambiguous, so quality should be 0
                     } else {
                         // check for ambiguity
                         if alleles[i] == rsa {
                             // quals won't always match in local mode
                             // it's also possible to have one quality from global and one from local; lets change this to max
-                            quals[i] = quals[i].max(rs_quals[i]);
+                            quals[i] = quals[i].max(rsq);
                             assert!(quals[i] > 0);
                         } else {
-                            // they don't match, change to ambiguous
-                            alleles[i] = 2;
+                            // they don't match, change to ambiguous and clear the quality cost
+                            alleles[i] = AlleleType::Ambiguous;
                             quals[i] = 0;
                         }
                     }
@@ -95,35 +133,33 @@ impl ReadSegment {
         &self.read_name
     }
 
-    pub fn get_num_alleles(&self) -> usize {
-        self.alleles.len()
+    /// Returns the allele value for the given index
+    pub fn allele(&self, index: usize) -> AlleleType {
+        if self.region.contains(&index) {
+            self.alleles[index - self.region.start]
+        } else {
+            AlleleType::NoOverlap
+        }
     }
 
-    pub fn alleles(&self) -> &[u8] {
-        &self.alleles[..]
+    /// Returns the quality value for the given index
+    pub fn qual(&self, index: usize) -> u8 {
+        if self.region.contains(&index) {
+            self.quals[index - self.region.start]
+        } else {
+            0
+        }
     }
 
-    pub fn quals(&self) -> &[u8] {
-        &self.quals[..]
-    }
-
-    pub fn first_allele(&self) -> usize {
-        self.first_allele
-    }
-
-    pub fn last_allele(&self) -> usize {
-        self.last_allele
-    }
-
-    /// Returns the range of this segment, e.g. [first_allele..last_allele+1)
-    pub fn get_range(&self) -> std::ops::Range<usize> {
-        self.first_allele..(self.last_allele+1)
+    /// Returns the range of this segment
+    pub fn region(&self) -> &std::ops::Range<usize> {
+        &self.region
     }
 
     /// Returns the number of alleles that are set (i.e. non-ambiguous and overlapping, so 0 or 1)
     pub fn get_num_set(&self) -> usize {
         self.alleles.iter()
-            .filter(|&v| *v < 2)
+            .filter(|&v| *v < AlleleType::Ambiguous)
             .count()
     }
 
@@ -131,8 +167,12 @@ impl ReadSegment {
     /// If a haplotype has a 2, no cost is associated with that allele.
     /// # Arguments
     /// `haplotype` - the full haplotype to score, must have the same length as the block
-    pub fn score_haplotype(&self, haplotype: &[u8]) -> u64 {
-        assert_eq!(self.alleles.len(), haplotype.len());
+    pub fn score_haplotype(&self, haplotype: &[AlleleType]) -> u64 {
+        // with clipped read segments, this no longer holds
+        // assert_eq!(self.alleles.len(), haplotype.len());
+        // however, the last allele should always be less than haplotype len, or else they've given us something too short
+        assert!(self.region.end <= haplotype.len());
+
         self.score_partial_haplotype(haplotype, 0)
     }
 
@@ -143,27 +183,33 @@ impl ReadSegment {
     /// # Arguments
     /// * `haplotype` - the partial haplotype to score
     /// * `offset` - the offset into the read segment to start scoring
-    pub fn score_partial_haplotype(&self, haplotype: &[u8], offset: usize) -> u64 {
-        //info!("rs {}+{} <= {}?", haplotype.len(), offset, self.alleles.len());
-        assert!(haplotype.len()+offset <= self.alleles.len());
-        if haplotype.len() + offset <= self.first_allele || offset > self.last_allele {
+    pub fn score_partial_haplotype(&self, haplotype: &[AlleleType], offset: usize) -> u64 {
+        // assertion does not work with clipped segments
+        // assert!(haplotype.len()+offset <= self.alleles.len());
+        if haplotype.len() + offset <= self.region.start || offset >= self.region.end {
             // the haplotype starts and ends before our first allele, OR
             // the haplotype starts after our last allele, SO
             // return 0 in either case, because there is no overlaps to score
             0
         } else {
             // the minimum comparison is either the first allele OR the offset, whichever is greater
-            let min_compare = self.first_allele.max(offset);
-
-            // if the allele component is greater, then we need to shift into the haplotype
-            let offset_shift = min_compare - offset;
+            let min_compare = self.region.start.max(offset);
 
             // the maximum comparison is either the last allele we have OR the end of the haplotype+start offset
-            let max_compare = (self.last_allele+1).min(offset+haplotype.len());
+            let max_compare = (self.region.end).min(offset+haplotype.len());
             
-            self.quals[min_compare..max_compare].iter().enumerate()
-                .filter(|(i, _q)| haplotype[*i+offset_shift] < 2 && self.alleles[*i+min_compare] != haplotype[*i+offset_shift])
-                .map(|(_i, &q)| q as u64)
+            // iterate over the region and add up the quality costs when they mismatch
+            (min_compare..max_compare)
+                .filter_map(|index| {
+                    let allele = self.allele(index);
+                    
+                    // keep if the allele is non-ambiguous
+                    if haplotype[index - offset] < AlleleType::Ambiguous && allele != haplotype[index - offset] {
+                        Some(self.qual(index) as u64)
+                    } else {
+                        None
+                    }
+                })
                 .sum()
         }
     }
@@ -174,50 +220,66 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_constructor() {
+        let rs = ReadSegment::new(
+            "read_name".to_string(),
+            vec![3_u8, 0, 1, 0, 0, 1, 2, 2, 3, 3].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect(),
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0]
+        );
+
+        assert_eq!(rs, ReadSegment {
+            read_name: "read_name".to_string(),
+            alleles: vec![0, 1, 0, 0, 1].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect(),
+            quals: vec![1, 2, 3, 4, 5],
+            region: 1..6
+        });
+    }
+
+    #[test]
     fn test_score_haplotype() {
         let rs = ReadSegment::new(
             "read_name".to_string(),
-            vec![2, 0, 1, 0, 0, 1, 2, 1, 2, 2],
-            vec![0, 1, 1, 1, 1, 1, 1, 1, 0, 0]
+            vec![3_u8, 0, 1, 0, 0, 1, 2, 1, 3, 3].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect(),
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0]
         );
-        assert_eq!(rs.first_allele, 1);
-        assert_eq!(rs.last_allele, 7);
+        assert_eq!(rs.region, 1..8);
         assert_eq!(rs.get_num_set(), 6);
 
         //identical except for missing value in rs
-        let haplotype = vec![0, 0, 1, 0, 0, 1, 1, 1, 0, 0];
-        assert_eq!(rs.score_haplotype(&haplotype), 1);
+        let haplotype: Vec<AlleleType> = vec![0_u8, 0, 1, 0, 0, 1, 1, 1, 0, 0].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect();
+        assert_eq!(rs.score_haplotype(&haplotype), 6);
         
         //fully empty haplotype
-        let haplotype = vec![2; 10];
+        let haplotype: Vec<AlleleType> = vec![2_u8; 10].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect();
         assert_eq!(rs.score_haplotype(&haplotype), 0);
 
         //fully wrong haplotype
-        let haplotype = vec![1, 1, 0, 1, 1, 0, 0, 0, 1, 1];
-        assert_eq!(rs.score_haplotype(&haplotype), 7);
+        let haplotype: Vec<AlleleType> = vec![1_u8, 1, 0, 1, 1, 0, 0, 0, 1, 1].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect();
+        assert_eq!(rs.score_haplotype(&haplotype), 1+2+3+4+5+6+7);
     }
 
     #[test]
     fn test_score_partial_haplotype() {
         let rs = ReadSegment::new(
             "read_name".to_string(),
-            vec![2, 0, 1, 0, 0, 1, 2, 1, 2, 2],
-            vec![0, 1, 1, 1, 1, 1, 1, 1, 0, 0]
+            vec![2_u8, 0, 1, 0, 0, 1, 2, 1, 2, 2].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect(),
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0]
         );
 
         //identical except for missing value in rs
-        let haplotype = vec![0, 1, 0, 0, 1, 1, 1];
-        assert_eq!(rs.score_partial_haplotype(&haplotype, 1), 1);
+        let haplotype: Vec<AlleleType> = vec![0, 1, 0, 0, 1, 1, 1].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect();
+        assert_eq!(rs.score_partial_haplotype(&haplotype, 1), 6);
         
         //fully empty haplotype
-        let haplotype = vec![2; 7];
+        let haplotype: Vec<AlleleType> = vec![2; 7].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect();
         assert_eq!(rs.score_partial_haplotype(&haplotype, 2), 0);
 
         //fully wrong haplotype
-        let haplotype = vec![1, 0, 1, 1, 0, 0, 0];
-        assert_eq!(rs.score_partial_haplotype(&haplotype, 1), 7);
+        let haplotype: Vec<AlleleType> = vec![1, 0, 1, 1, 0, 0, 0].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect();
+        assert_eq!(rs.score_partial_haplotype(&haplotype, 1), 1+2+3+4+5+6+7);
+        
         for x in 0..haplotype.len() {
-            assert_eq!(rs.score_partial_haplotype(&haplotype[x..], 1+x), 7-x as u64);
+            assert_eq!(rs.score_partial_haplotype(&haplotype[x..], 1+x), ((x+1)..8).sum::<usize>() as u64);
         }
     }
 
@@ -225,29 +287,28 @@ mod tests {
     fn test_collapse() {
         let rs1 = ReadSegment::new(
             "read_name".to_string(),
-            vec![3, 1, 0, 2, 1, 3, 3],
+            vec![3, 1, 0, 2, 1, 3, 3].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect(),
             vec![0, 2, 1, 0, 2, 0, 0]
         );
         let rs2 = ReadSegment::new(
             "read_name".to_string(),
-            vec![3, 3, 0, 1, 0, 1, 1],
+            vec![3, 3, 0, 1, 0, 1, 1].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect(),
             vec![0, 0, 1, 2, 2, 1, 1]
         );
         let expected = ReadSegment::new(
             "read_name".to_string(),
-            vec![3, 1, 0, 2, 2, 1, 1],
+            vec![3, 1, 0, 2, 2, 1, 1].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect(),
             vec![0, 2, 1, 0, 0, 1, 1]
         );
 
         // make sure normal collapsing works
         let collapsed = ReadSegment::collapse(&[rs1.clone(), rs2.clone()]);
         assert_eq!(expected, collapsed);
-        assert_eq!(collapsed.first_allele, 1);
-        assert_eq!(collapsed.last_allele, 6);
+        assert_eq!(collapsed.region, 1..7);
 
         // make sure scoring works fine with the 3s present
         //              vec![3, 1, 0, 2, 2, 1, 1]
-        let haplotype = vec![0, 1, 0, 0, 0, 1, 0];
+        let haplotype: Vec<AlleleType> = vec![0_u8, 1, 0, 0, 0, 1, 0].into_iter().map(|v| AlleleType::from_repr(v).unwrap()).collect();
         assert_eq!(collapsed.score_haplotype(&haplotype), 1);
 
         // check stupid collapsing also

--- a/src/data_types/read_segments.rs
+++ b/src/data_types/read_segments.rs
@@ -1,28 +1,19 @@
 
 use std::ops::Range;
 
+/// Types of alleles that are used for phasing
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, strum_macros::FromRepr)]
 pub enum AlleleType {
+    /// Matches the "Reference" allele; this may not actually be reference in a multi-allelic site
     Reference=0,
+    /// Matches the "Alternate" allele at a site
     Alternate=1,
+    /// Typically means that it equally matches both possible alleles
     Ambiguous=2,
+    /// Indicates that the type cannot be determined due to lack of overlap
     NoOverlap=3
 }
-
-/*
-impl From<u8> for AlleleType {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => AlleleType::Reference,
-            1 => AlleleType::Alternate,
-            2 => AlleleType::Ambiguous,
-            3 => AlleleType::NoOverlap,
-            _ => AlleleType::NoOverlap
-        }
-    }
-}
-*/
 
 /// Container for a read segment that has been converted into a variant representation
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/wfa_graph.rs
+++ b/src/wfa_graph.rs
@@ -1,4 +1,5 @@
 
+use crate::data_types::read_segments::AlleleType;
 use crate::data_types::variants::Variant;
 
 use bit_vec::BitVec;
@@ -213,7 +214,7 @@ impl WFAGraph {
             }
 
             // now add the alt allele(s)
-            if variant.convert_index(0) != 0 {
+            if variant.convert_index(AlleleType::Reference) != 0 {
                 // allele0 is an alt, so this must be multi-allelic; basically do the same thing we would do for allele1
                 // add the sequence exactly with just the immediately upstream reference node
                 let alt_sequence: Vec<u8> = variant.get_truncated_allele0().to_vec();

--- a/src/writers/ordered_vcf_writer.rs
+++ b/src/writers/ordered_vcf_writer.rs
@@ -1,5 +1,6 @@
 
 use crate::block_gen::is_phasable_variant;
+use crate::data_types::read_segments::AlleleType;
 use crate::phaser::PhaseResult;
 
 use log::{debug, trace};
@@ -222,7 +223,7 @@ impl OrderedVcfWriter {
                         for (haplotype_index, &h1_index) in phase_result.haplotype_1.iter().enumerate() {
                             if vcf_index == phase_result.variants[haplotype_index].get_vcf_index() {
                                 // h1 and h2 are just internal representations
-                                let h2_index: u8 = phase_result.haplotype_2[haplotype_index];
+                                let h2_index: AlleleType = phase_result.haplotype_2[haplotype_index];
 
                                 // convert them to the file representations where possible
                                 let h1 = phase_result.variants[haplotype_index].convert_index(h1_index);


### PR DESCRIPTION
# v1.5.0
## Changes
* Reduced memory footprint for large putative phase blocks by adjusting algorithms for storing read segment variants. Overall, this change has a negligible impact on memory usage for a typical human WGS dataset. However, sample types with much higher heterozygous variants per phase block (e.g., mouse) have significantly less peak memory usage (>80% reduction on tests).
* Minor tweaks to phasing methods to reduce overhead of tracking candidate phase solutions
* Internal results are highly similar, but not identical, to results for v1.4.5